### PR TITLE
Use absolute paths for Source Extractor configuration files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zogy"
-version = '0.63'
+version = '0.64'
 requires-python = ">=3.8"
 dependencies = [
     'argparse==1.1',

--- a/zogy/Settings/Constants.py
+++ b/zogy/Settings/Constants.py
@@ -1,4 +1,4 @@
-
+from importlib import resources
 __version__ = '0.6'
 
 #===============================================================================
@@ -107,7 +107,7 @@ psf_stars_s2n_min = 20   # minimum signal-to-noise ratio for PSF stars
 # Astrometry
 #===============================================================================
 # WCS
-skip_wcs = Talse         # skip Astrometry.net step if image already
+skip_wcs = False         # skip Astrometry.net step if image already
                          # contains a reliable WCS solution
 # Astrometry.net's tweak order
 astronet_tweak_order = 3
@@ -154,14 +154,14 @@ zp_default = {'u':24., 'g':24., 'q':24., 'r':24., 'i':24., 'z':24.}
 # Configuration
 #===============================================================================
 # path and names of configuration files
-cfg_dir = './Config/'
-sex_cfg = cfg_dir+'sex.config'               # SExtractor configuration file
-sex_cfg_psffit = cfg_dir+'sex_psffit.config' # same for PSF-fitting version
-sex_par = cfg_dir+'sex.params'               # SExtractor output parameters definition file
-sex_par_psffit = cfg_dir+'sex_psffit.params' # same for PSF-fitting version
-sex_par_ref = cfg_dir+'sex_ref.params'       # same for reference image output version
-psfex_cfg = cfg_dir+'psfex.config'           # PSFex configuration file
-swarp_cfg = cfg_dir+'swarp.config'           # SWarp configuration file
+cfg_dir = str(resources.files('zogy').joinpath('Config'))
+sex_cfg = cfg_dir+'/sex.config'               # SExtractor configuration file
+sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
+sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file
+sex_par_psffit = cfg_dir+'/sex_psffit.params' # same for PSF-fitting version
+sex_par_ref = cfg_dir+'/sex_ref.params'       # same for reference image output version
+psfex_cfg = cfg_dir+'/psfex.config'           # PSFex configuration file
+swarp_cfg = cfg_dir+'/swarp.config'           # SWarp configuration file
 
 # if a mask image is provided, the mask values can be associated to
 # the type of masked pixel with this dictionary:

--- a/zogy/Settings/Constants.py
+++ b/zogy/Settings/Constants.py
@@ -1,4 +1,4 @@
-from importlib import resources
+from importlib_resources import files
 __version__ = '0.6'
 
 #===============================================================================
@@ -154,7 +154,7 @@ zp_default = {'u':24., 'g':24., 'q':24., 'r':24., 'i':24., 'z':24.}
 # Configuration
 #===============================================================================
 # path and names of configuration files
-cfg_dir = str(resources.files('zogy').joinpath('Config'))
+cfg_dir = str(files('zogy').joinpath('Config'))
 sex_cfg = cfg_dir+'/sex.config'               # SExtractor configuration file
 sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file

--- a/zogy/Settings/Constants.py
+++ b/zogy/Settings/Constants.py
@@ -160,6 +160,8 @@ sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file
 sex_par_psffit = cfg_dir+'/sex_psffit.params' # same for PSF-fitting version
 sex_par_ref = cfg_dir+'/sex_ref.params'       # same for reference image output version
+sex_conv = cfg_dir + '/default.conv'          # SExtractor filter file
+sex_nnw = cfg_dir + '/default.nnw'            # SExtractor neural-network weight table file
 psfex_cfg = cfg_dir+'/psfex.config'           # PSFex configuration file
 swarp_cfg = cfg_dir+'/swarp.config'           # SWarp configuration file
 

--- a/zogy/Settings/Constants_css.py
+++ b/zogy/Settings/Constants_css.py
@@ -169,6 +169,8 @@ sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file
 sex_par_psffit = cfg_dir+'/sex_psffit.params' # same for PSF-fitting version
 sex_par_ref = cfg_dir+'/sex_ref.params'       # same for reference image output version
+sex_conv = cfg_dir + '/default.conv'          # SExtractor filter file
+sex_nnw = cfg_dir + '/default.nnw'            # SExtractor neural-network weight table file
 psfex_cfg = cfg_dir+'/psfex.config'           # PSFex configuration file
 swarp_cfg = cfg_dir+'/swarp_css.config'           # SWarp configuration file
 

--- a/zogy/Settings/Constants_css.py
+++ b/zogy/Settings/Constants_css.py
@@ -1,4 +1,4 @@
-from importlib import resources
+from importlib_resources import files
 __version__ = '0.1'
 
 #===============================================================================
@@ -163,7 +163,7 @@ min_stars = 100
 # Configuration
 #===============================================================================
 # path and names of configuration files
-cfg_dir = str(resources.files('zogy').joinpath('Config'))
+cfg_dir = str(files('zogy').joinpath('Config'))
 sex_cfg = cfg_dir+'/sex.config'               # SExtractor configuration file
 sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file

--- a/zogy/Settings/Constants_css.py
+++ b/zogy/Settings/Constants_css.py
@@ -1,4 +1,4 @@
-
+from importlib import resources
 __version__ = '0.1'
 
 #===============================================================================
@@ -163,7 +163,7 @@ min_stars = 100
 # Configuration
 #===============================================================================
 # path and names of configuration files
-cfg_dir = './Config'
+cfg_dir = str(resources.files('zogy').joinpath('Config'))
 sex_cfg = cfg_dir+'/sex.config'               # SExtractor configuration file
 sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file

--- a/zogy/Settings/Constants_meerlicht.py
+++ b/zogy/Settings/Constants_meerlicht.py
@@ -1,4 +1,4 @@
-
+from importlib import resources
 __version__ = '0.62'
 
 #===============================================================================
@@ -154,14 +154,14 @@ zp_default = {'u':24., 'g':24., 'q':24., 'r':24., 'i':24., 'z':24.}
 # Configuration
 #===============================================================================
 # path and names of configuration files
-cfg_dir = './Config/'
-sex_cfg = cfg_dir+'sex.config'               # SExtractor configuration file
-sex_cfg_psffit = cfg_dir+'sex_psffit.config' # same for PSF-fitting version
-sex_par = cfg_dir+'sex.params'               # SExtractor output parameters definition file
-sex_par_psffit = cfg_dir+'sex_psffit.params' # same for PSF-fitting version
-sex_par_ref = cfg_dir+'sex_ref.params'       # same for reference image output version
-psfex_cfg = cfg_dir+'psfex.config'           # PSFex configuration file
-swarp_cfg = cfg_dir+'swarp.config'           # SWarp configuration file
+cfg_dir = str(resources.files('zogy').joinpath('Config'))
+sex_cfg = cfg_dir+'/sex.config'               # SExtractor configuration file
+sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
+sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file
+sex_par_psffit = cfg_dir+'/sex_psffit.params' # same for PSF-fitting version
+sex_par_ref = cfg_dir+'/sex_ref.params'       # same for reference image output version
+psfex_cfg = cfg_dir+'/psfex.config'           # PSFex configuration file
+swarp_cfg = cfg_dir+'/swarp.config'           # SWarp configuration file
 
 # if a mask image is provided, the mask values can be associated to
 # the type of masked pixel with this dictionary:

--- a/zogy/Settings/Constants_meerlicht.py
+++ b/zogy/Settings/Constants_meerlicht.py
@@ -1,4 +1,4 @@
-from importlib import resources
+from importlib_resources import files
 __version__ = '0.62'
 
 #===============================================================================
@@ -154,7 +154,7 @@ zp_default = {'u':24., 'g':24., 'q':24., 'r':24., 'i':24., 'z':24.}
 # Configuration
 #===============================================================================
 # path and names of configuration files
-cfg_dir = str(resources.files('zogy').joinpath('Config'))
+cfg_dir = str(files('zogy').joinpath('Config'))
 sex_cfg = cfg_dir+'/sex.config'               # SExtractor configuration file
 sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file

--- a/zogy/Settings/Constants_meerlicht.py
+++ b/zogy/Settings/Constants_meerlicht.py
@@ -160,6 +160,8 @@ sex_cfg_psffit = cfg_dir+'/sex_psffit.config' # same for PSF-fitting version
 sex_par = cfg_dir+'/sex.params'               # SExtractor output parameters definition file
 sex_par_psffit = cfg_dir+'/sex_psffit.params' # same for PSF-fitting version
 sex_par_ref = cfg_dir+'/sex_ref.params'       # same for reference image output version
+sex_conv = cfg_dir + '/default.conv'          # SExtractor filter file
+sex_nnw = cfg_dir + '/default.nnw'            # SExtractor neural-network weight table file
 psfex_cfg = cfg_dir+'/psfex.config'           # PSFex configuration file
 swarp_cfg = cfg_dir+'/swarp.config'           # SWarp configuration file
 

--- a/zogy/zogy.py
+++ b/zogy/zogy.py
@@ -5040,7 +5040,7 @@ def run_sextractor(image, cat_out, file_config, file_params, pixscale, log, head
            '-PARAMETERS_NAME', file_params, '-PIXEL_SCALE', str(pixscale),
            '-SEEING_FWHM', str(seeing),'-PHOT_APERTURES',apphot_diams_str,
            '-BACK_SIZE', str(C.bkg_boxsize), '-BACK_FILTERSIZE', str(C.bkg_filtersize),
-           '-NTHREADS', str(nthreads)]
+           '-NTHREADS', str(nthreads), '-FILTER_NAME', C.sex_conv, '-STARNNW_NAME', C.sex_nnw]
 
     # add commands to produce BACKGROUND, BACKGROUND_RMS and
     # background-subtracted image with all pixels where objects were


### PR DESCRIPTION
Because these configuration files are now installed, but the code can be run from anywhere, we need to give the full paths to the installed files.